### PR TITLE
Fix blacklist_library, move skip to function

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,17 +1,30 @@
+# Do not mark any shows/movies as played and instead just output to log if they would of been marked.
 DRYRUN = "True"
+# Additional logging information
 DEBUG = "True"
+# How often to run the script in seconds
 SLEEP_DURATION = "3600"
+# Log file where all output will be written to
 LOGFILE = "log.log"
+# Map usernames between plex and jellyfin in the event that they are different, order does not matter
 #USER_MAPPING = { "testuser2": "testuser3" }
+# Map libraries between plex and jellyfin in the even that they are different, order does not matter
 #LIBRARY_MAPPING = { "Shows": "TV Shows" }
 
+# URL of the plex server, use hostname or IP address if the hostname is not resolving correctly
 PLEX_BASEURL = "http://localhost:32400"
+# Plex token https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
 PLEX_TOKEN = "SuperSecretToken"
+# If not using plex token then use username and password of the server admin
 #PLEX_USERNAME = ""
 #PLEX_PASSWORD = ""
+
+# Jellyfin server URL, use hostname or IP address if the hostname is not resolving correctly
 JELLYFIN_BASEURL = "http://localhost:8096"
+# Jellyfin api token, created manually by logging in to the jellyfin server admin dashboard and creating an api key
 JELLYFIN_TOKEN = "SuperSecretToken"
 
+# Blacklisting/Whitelisting libraries, library types such as Movies, TV Shows, and users. Mappings apply so if the mapping for the user or library exist then both will be excluded.
 #BLACKLIST_LIBRARY = ""
 #WHITELIST_LIBRARY = ""
 #BLACKLIST_LIBRARY_TYPE = "" 

--- a/src/functions.py
+++ b/src/functions.py
@@ -33,7 +33,43 @@ def str_to_bool(value: any) -> bool:
 def search_mapping(dictionary: dict, key_value: str):
     if key_value in dictionary.keys():
         return dictionary[key_value]
+    elif key_value.lower() in dictionary.keys():
+        return dictionary[key_value]
     elif key_value in dictionary.values():
+        return list(dictionary.keys())[list(dictionary.values()).index(key_value)]
+    elif key_value.lower() in dictionary.values():
         return list(dictionary.keys())[list(dictionary.values()).index(key_value)]
     else:
         return None
+
+
+def check_skip_logic(library_title, library_type, blacklist_library, whitelist_library, blacklist_library_type, whitelist_library_type, library_mapping):
+    skip_reason = None
+
+    if library_type.lower() in blacklist_library_type:
+        skip_reason = "is blacklist_library_type"
+
+    if library_title.lower() in [x.lower() for x in blacklist_library]:
+        skip_reason = "is blacklist_library"
+
+    library_other = None
+    if library_mapping:
+        library_other = search_mapping(library_mapping, library_title)
+    if library_other:
+        if library_other.lower() in [x.lower() for x in blacklist_library]:
+            skip_reason = "is blacklist_library"
+
+    if len(whitelist_library_type) > 0:
+        if library_type.lower() not in whitelist_library_type:
+            skip_reason = "is not whitelist_library_type"
+
+    # if whitelist is not empty and library is not in whitelist
+    if len(whitelist_library) > 0:
+        if library_title.lower() not in [x.lower() for x in whitelist_library]:
+            skip_reason = "is not whitelist_library"
+        
+        if library_other:
+            if library_other.lower() not in [x.lower() for x in whitelist_library]:
+                skip_reason = "is not whitelist_library"
+
+    return skip_reason

--- a/src/jellyfin.py
+++ b/src/jellyfin.py
@@ -1,6 +1,6 @@
 import requests, os
 from dotenv import load_dotenv
-from src.functions import logger, search_mapping, str_to_bool
+from src.functions import logger, search_mapping, str_to_bool, check_skip_logic
 
 load_dotenv(override=True)
 
@@ -76,38 +76,11 @@ class Jellyfin():
                 else:
                     library_type = watched["Items"][0]["Type"]
 
-                if library_type.lower() in blacklist_library_type:
-                    logger(f"Jellyfin: Library type {library_type} is blacklist_library_type", 1)
+                skip_reason = check_skip_logic(library_title, library_type, blacklist_library, whitelist_library, blacklist_library_type, whitelist_library_type, library_mapping)
+
+                if skip_reason:
+                    logger(f"Jellyfin: Skipping library {library_title} {skip_reason}", 1)
                     continue
-
-                if library_title.lower() in [x.lower() for x in blacklist_library]:
-                    logger(f"Jellyfin: Library {library_title} is blacklist_library", 1)
-                    continue
-
-                library_other = None
-                if library_mapping:
-                    library_other = search_mapping(library_mapping, library_title)
-                if library_other:
-                    library_other.lower()
-                    if library_other not in [x.lower() for x in blacklist_library]:
-                        logger(f"Jellyfin: Library {library_other} is blacklist_library", 1)
-                        continue
-
-                if len(whitelist_library_type) > 0:
-                    if library_type.lower() not in whitelist_library_type:
-                        logger(f"Jellyfin: Library type {library_type} is not whitelist_library_type", 1)
-                        continue
-
-                # if whitelist is not empty and library is not in whitelist
-                if len(whitelist_library) > 0:
-                    if library_title.lower() not in [x.lower() for x in whitelist_library]:
-                        logger(f"Jellyfin: Library {library_title} is not whitelist_library", 1)
-                        continue
-                    
-                    if library_other:
-                        if library_other not in [x.lower() for x in whitelist_library]:
-                            logger(f"Jellyfin: Library {library_other} is not whitelist_library", 1)
-                            continue
 
                 logger(f"Jellyfin: Generating watched for {user_name} in library {library_title}", 0)
                 # Movies

--- a/src/plex.py
+++ b/src/plex.py
@@ -1,7 +1,7 @@
 import re, os
 from dotenv import load_dotenv
 
-from src.functions import logger, search_mapping
+from src.functions import logger, search_mapping, check_skip_logic
 from plexapi.server import PlexServer
 from plexapi.myplex import MyPlexAccount
 
@@ -103,38 +103,11 @@ class Plex:
             library_title = library.title
             library_type = library.type
 
-            if library_type.lower() in blacklist_library_type:
-                logger(f"Plex: Library type {library_type} is blacklist_library_type", 1)
+            skip_reason = check_skip_logic(library_title, library_type, blacklist_library, whitelist_library, blacklist_library_type, whitelist_library_type, library_mapping)
+
+            if skip_reason:
+                logger(f"Plex: Skipping library {library_title} {skip_reason}", 1)
                 continue
-
-            if library_title.lower() in [x.lower() for x in blacklist_library]:
-                logger(f"Plex: Library {library_title} is blacklist_library", 1)
-                continue
-
-            library_other = None
-            if library_mapping:
-                library_other = search_mapping(library_mapping, library_title)
-            if library_other:
-                library_other.lower()
-                if library_other not in [x.lower() for x in blacklist_library]:
-                    logger(f"Plex: Library {library_other} is blacklist_library", 1)
-                    continue
-
-            if len(whitelist_library_type) > 0:
-                if library_type.lower() not in whitelist_library_type:
-                    logger(f"Plex: Library type {library_type} is not whitelist_library_type", 1)
-                    continue
-
-            # if whitelist is not empty and library is not in whitelist
-            if len(whitelist_library) > 0:
-                if library_title.lower() not in [x.lower() for x in whitelist_library]:
-                    logger(f"Plex: Library {library_title} is not whitelist_library", 1)
-                    continue
-                
-                if library_other:
-                    if library_other not in [x.lower() for x in whitelist_library]:
-                        logger(f"Plex: Library {library_other} is not whitelist_library", 1)
-                        continue
             
             for user in users:
                 logger(f"Plex: Generating watched for {user.title} in library {library_title}", 0)


### PR DESCRIPTION
There was a stray not in the blacklist function check.

Moved skip library check to a function so it is the same for both plex and jellyfin and easier to update.