### PR TITLE
Fix plex login, Match plex marking logic to jellyfin

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,30 +1,35 @@
-# Do not mark any shows/movies as played and instead just output to log if they would of been marked.
+## Do not mark any shows/movies as played and instead just output to log if they would of been marked.
 DRYRUN = "True"
-# Additional logging information
+## Additional logging information
 DEBUG = "True"
-# How often to run the script in seconds
+## How often to run the script in seconds
 SLEEP_DURATION = "3600"
-# Log file where all output will be written to
+## Log file where all output will be written to
 LOGFILE = "log.log"
-# Map usernames between plex and jellyfin in the event that they are different, order does not matter
+## Map usernames between plex and jellyfin in the event that they are different, order does not matter
 #USER_MAPPING = { "testuser2": "testuser3" }
-# Map libraries between plex and jellyfin in the even that they are different, order does not matter
+## Map libraries between plex and jellyfin in the even that they are different, order does not matter
 #LIBRARY_MAPPING = { "Shows": "TV Shows" }
 
-# URL of the plex server, use hostname or IP address if the hostname is not resolving correctly
+
+## Recommended to use token as it is faster to connect as it is direct to the server instead of going through the plex servers
+## URL of the plex server, use hostname or IP address if the hostname is not resolving correctly
 PLEX_BASEURL = "http://localhost:32400"
-# Plex token https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
+## Plex token https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
 PLEX_TOKEN = "SuperSecretToken"
-# If not using plex token then use username and password of the server admin
+## If not using plex token then use username and password of the server admin along with the servername
 #PLEX_USERNAME = ""
 #PLEX_PASSWORD = ""
+#PLEX_SERVERNAME = "Plex Server"
 
-# Jellyfin server URL, use hostname or IP address if the hostname is not resolving correctly
+
+## Jellyfin server URL, use hostname or IP address if the hostname is not resolving correctly
 JELLYFIN_BASEURL = "http://localhost:8096"
-# Jellyfin api token, created manually by logging in to the jellyfin server admin dashboard and creating an api key
+## Jellyfin api token, created manually by logging in to the jellyfin server admin dashboard and creating an api key
 JELLYFIN_TOKEN = "SuperSecretToken"
 
-# Blacklisting/Whitelisting libraries, library types such as Movies, TV Shows, and users. Mappings apply so if the mapping for the user or library exist then both will be excluded.
+
+## Blacklisting/Whitelisting libraries, library types such as Movies/TV Shows, and users. Mappings apply so if the mapping for the user or library exist then both will be excluded.
 #BLACKLIST_LIBRARY = ""
 #WHITELIST_LIBRARY = ""
 #BLACKLIST_LIBRARY_TYPE = "" 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JellyPlex-Watched
 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/26b47c5db63942f28f02f207f692dc85)](https://www.codacy.com/gh/luigi311/JellyPlex-Watched/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=luigi311/JellyPlex-Watched&amp;utm_campaign=Badge_Grade)
+
 Sync watched between jellyfin and plex
 
 ## Description

--- a/src/functions.py
+++ b/src/functions.py
@@ -67,7 +67,7 @@ def check_skip_logic(library_title, library_type, blacklist_library, whitelist_l
     if len(whitelist_library) > 0:
         if library_title.lower() not in [x.lower() for x in whitelist_library]:
             skip_reason = "is not whitelist_library"
-        
+
         if library_other:
             if library_other.lower() not in [x.lower() for x in whitelist_library]:
                 skip_reason = "is not whitelist_library"

--- a/src/jellyfin.py
+++ b/src/jellyfin.py
@@ -14,7 +14,7 @@ class Jellyfin():
 
         if not self.baseurl:
             raise Exception("Jellyfin baseurl not set")
-        
+
         if not self.token:
             raise Exception("Jellyfin token not set")
 
@@ -27,7 +27,7 @@ class Jellyfin():
 
             if query_type == "get":
                 response = requests.get(self.baseurl + query, headers={"accept":"application/json", "X-Emby-Token": self.token})
-            
+
             elif query_type == "post":
                 authorization = (
                     'MediaBrowser , '
@@ -42,19 +42,19 @@ class Jellyfin():
         except Exception as e:
             logger(e, 2)
             logger(response, 2)
-            
+
     def get_users(self):
         users = {}
 
         query = "/Users"
         response = self.query(query, "get")
-        
+
         # If reponse is not empty
         if response:
             for user in response:
                 users[user["Name"]] = user["Id"]
 
-        return users  
+        return users
 
     def get_jellyfin_watched(self, users, blacklist_library, whitelist_library, blacklist_library_type, whitelist_library_type, library_mapping=None):
         users_watched = {}
@@ -64,12 +64,12 @@ class Jellyfin():
             user_name = user_name.lower()
 
             libraries = self.query(f"/Users/{user_id}/Views", "get")["Items"]
-            
+
             for library in libraries:
                 library_title = library["Name"]
                 library_id = library["Id"]
                 watched = self.query(f"/Users/{user_id}/Items?SortBy=SortName&SortOrder=Ascending&Recursive=true&ParentId={library_id}&Filters=IsPlayed&limit=1", "get")
-                
+
                 if len(watched["Items"]) == 0:
                     logger(f"Jellyfin: No watched items found in library {library_title}", 1)
                     continue
@@ -123,7 +123,7 @@ class Jellyfin():
                                                 # Lowercase episode["ProviderIds"] keys
                                                 episode["ProviderIds"] = {k.lower(): v for k, v in episode["ProviderIds"].items()}
                                                 users_watched[user_name][library_title][show["Name"]][season["Name"]].append(episode["ProviderIds"])
-                            
+
         return users_watched
 
     def update_watched(self, watched_list, user_mapping=None, library_mapping=None, dryrun=False):
@@ -135,7 +135,7 @@ class Jellyfin():
                     user_other = user_mapping[user]
                 elif user in user_mapping.values():
                     user_other = search_mapping(user_mapping, user)
-                
+
                 if user_other:
                     logger(f"Swapping user {user} with {user_other}", 1)
                     user = user_other
@@ -145,13 +145,13 @@ class Jellyfin():
                 if user.lower() == key.lower():
                     user_id = self.users[key]
                     break
-            
+
             if not user_id:
                 logger(f"{user} not found in Jellyfin", 2)
                 break
-            
+
             jellyfin_libraries = self.query(f"/Users/{user_id}/Views", "get")["Items"]
-            
+
             for library, videos in libraries.items():
                 if library_mapping:
                     library_other = None
@@ -160,7 +160,7 @@ class Jellyfin():
                         library_other = library_mapping[library]
                     elif library in library_mapping.values():
                         library_other = search_mapping(library_mapping, library)
-                    
+
                     if library_other:
                         logger(f"Swapping library {library} with {library_other}", 1)
                         library = library_other
@@ -174,7 +174,7 @@ class Jellyfin():
                     if jellyfin_library["Name"] == library:
                         library_id = jellyfin_library["Id"]
                         continue
-                
+
                 if library_id:
                     logger(f"Jellyfin: Updating watched for {user} in library {library}", 1)
                     library_search = self.query(f"/Users/{user_id}/Items?SortBy=SortName&SortOrder=Ascending&Recursive=true&ParentId={library_id}&limit=1", "get")
@@ -196,7 +196,7 @@ class Jellyfin():
                                             else:
                                                 logger(f"Dryrun {msg}", 0)
                                             break
-                    
+
                     # TV Shows
                     if library_type == "Episode":
                         jellyfin_search = self.query(f"/Users/{user_id}/Items?SortBy=SortName&SortOrder=Ascending&Recursive=true&ParentId={library_id}&isPlayed=false", "get")

--- a/src/plex.py
+++ b/src/plex.py
@@ -11,6 +11,7 @@ plex_baseurl = os.getenv("PLEX_BASEURL")
 plex_token = os.getenv("PLEX_TOKEN")
 username = os.getenv("PLEX_USERNAME")
 password = os.getenv("PLEX_PASSWORD")
+servername = os.getenv("PLEX_SERVERNAME")
 
 # class plex accept base url and token and username and password but default with none
 class Plex:
@@ -19,25 +20,32 @@ class Plex:
         self.token = plex_token
         self.username = username
         self.password = password
+        self.servername = servername
         self.plex = self.plex_login()
         self.admin_user = self.plex.myPlexAccount()
         self.users = self.get_plex_users()
 
     def plex_login(self):
-        if self.baseurl:
-            if self.token:
-                # Login via token
-                plex = PlexServer(self.baseurl, self.token)
-            elif self.username and self.password:
+        try:
+            if self.baseurl and self.token:
+                    # Login via token
+                    plex = PlexServer(self.baseurl, self.token)
+            elif self.username and self.password and self.servername:
                 # Login via plex account
                 account = MyPlexAccount(self.username, self.password)
-                plex = account.resource(self.baseurl).connect()
+                plex = account.resource(self.servername).connect()
             else:
-                raise Exception("No plex credentials provided")
-        else:
-            raise Exception("No plex baseurl provided")
-
-        return plex
+                raise Exception("No complete plex credentials provided")
+            
+            return plex
+        except Exception as e:
+            if self.username or self.password:
+                msg = f"Failed to login via plex account {self.username}"
+                logger(f"Plex: Failed to login, {msg}, Error: {e}", 2)
+            else:
+                logger(f"Plex: Failed to login, Error: {e}", 2)
+            return None
+            
 
     def get_plex_users(self):
         users = self.plex.myPlexAccount().users()


### PR DESCRIPTION
Fix issue with plex login using the baseurl instead of the servername for the connection when logging in via username/password

Use the same logic from jellyfin on plex when marking episodes as watched.
