### PR TITLE
[Feature] Add flags to control the direction of syncing between the servers

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -55,6 +55,12 @@ PLEX_TOKEN = "SuperSecretToken, SuperSecretToken2"
 ## Set to True if running into ssl certificate errors
 SSL_BYPASS = "False"
 
+## control the direction of syncing. e.g. SYNC_FROM_PLEX_TO_JELLYFIN set to true will cause the updates from plex
+## to be updated in jellyfin. SYNC_FROM_PLEX_TO_PLEX set to true will sync updates between multiple plex servers
+SYNC_FROM_PLEX_TO_JELLYFIN = "True"
+SYNC_FROM_JELLYFIN_TO_PLEX = "True"
+SYNC_FROM_PLEX_TO_PLEX = "True"
+SYNC_FROM_JELLYFIN_TO_JELLYFIN = "True"
 
 
 # Jellyfin


### PR DESCRIPTION
As requested in #34, This PR adds 4 flags to control syncing between servers. 

- `SYNC_FROM_PLEX_TO_JELLYFIN` to allow updates from plex servers to update jellyfin servers
- `SYNC_FROM_JELLYFIN_TO_PLEX` to allow updates from jellyfin servers to update plex servers
- `SYNC_FROM_PLEX_TO_PLEX` to allow updates between plex servers
- `SYNC_FROM_JELLYFIN_TO_JELLYFIN` to allow updates between jellyfin servers

All flags default to true, which is normal operations before this PR.

closes #34