### PR TITLE
Use season number instead of season name

### DIFF
--- a/src/jellyfin.py
+++ b/src/jellyfin.py
@@ -331,8 +331,9 @@ class Jellyfin:
                         if len(seasons["Items"]) > 0:
                             for season in seasons["Items"]:
                                 season_identifiers = dict(seasons["Identifiers"])
-                                season_identifiers["season_id"] = season["Id"]
-                                season_identifiers["season_name"] = season["Name"]
+                                season_identifiers["season_index"] = season[
+                                    "IndexNumber"
+                                ]
                                 watched_task = asyncio.ensure_future(
                                     self.query(
                                         f"/Shows/{season_identifiers['show_id']}/Episodes"
@@ -390,18 +391,18 @@ class Jellyfin:
                                 ] = {}
 
                             if (
-                                season_dict["Identifiers"]["season_name"]
+                                season_dict["Identifiers"]["season_index"]
                                 not in user_watched[user_name][library_title][
                                     season_dict["Identifiers"]["show_guids"]
                                 ]
                             ):
                                 user_watched[user_name][library_title][
                                     season_dict["Identifiers"]["show_guids"]
-                                ][season_dict["Identifiers"]["season_name"]] = []
+                                ][season_dict["Identifiers"]["season_index"]] = []
 
                             user_watched[user_name][library_title][
                                 season_dict["Identifiers"]["show_guids"]
-                            ][season_dict["Identifiers"]["season_name"]] = season_dict[
+                            ][season_dict["Identifiers"]["season_index"]] = season_dict[
                                 "Episodes"
                             ]
                             logger(

--- a/src/plex.py
+++ b/src/plex.py
@@ -105,17 +105,17 @@ def get_user_library_watched_show(show):
 
         for episode in show.episodes():
             if episode in watched:
-                if episode.parentTitle not in episode_guids:
-                    episode_guids[episode.parentTitle] = []
+                if episode.parentIndex not in episode_guids:
+                    episode_guids[episode.parentIndex] = []
 
-                episode_guids[episode.parentTitle].append(
+                episode_guids[episode.parentIndex].append(
                     get_episode_guids(episode, show, completed=True)
                 )
             elif episode.viewOffset > 0:
-                if episode.parentTitle not in episode_guids:
-                    episode_guids[episode.parentTitle] = []
+                if episode.parentIndex not in episode_guids:
+                    episode_guids[episode.parentIndex] = []
 
-                episode_guids[episode.parentTitle].append(
+                episode_guids[episode.parentIndex].append(
                     get_episode_guids(episode, show, completed=False)
                 )
 


### PR DESCRIPTION
Using season name is not reliable as it can vary between servers and can be overridden by the user.