### PR TITLE
Add tini for sigterm handling

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -33,7 +33,8 @@ ENV BLACKLIST_USERS  ''
 ENV WHITELIST_USERS  ''
 
 
-RUN addgroup --system jellyplex_user && \
+RUN apk add --no-cache tini && \
+    addgroup --system jellyplex_user && \
     adduser --system --no-create-home jellyplex_user --ingroup jellyplex_user && \
     mkdir -p /app && \
     chown -R jellyplex_user:jellyplex_user /app
@@ -48,4 +49,5 @@ COPY --chown=jellyplex_user:jellyplex_user . .
 
 USER jellyplex_user
 
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["python", "-u", "main.py"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -33,7 +33,11 @@ ENV BLACKLIST_USERS  ''
 ENV WHITELIST_USERS  ''
 
 
-RUN addgroup --system jellyplex_user && \
+RUN apt-get update && \
+    apt-get install tini --yes --no-install-recommends && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    addgroup --system jellyplex_user && \
     adduser --system --no-create-home jellyplex_user --ingroup jellyplex_user && \
     mkdir -p /app && \
     chown -R jellyplex_user:jellyplex_user /app
@@ -48,4 +52,5 @@ COPY --chown=jellyplex_user:jellyplex_user . .
 
 USER jellyplex_user
 
+ENTRYPOINT ["/bin/tini", "--"]
 CMD ["python", "-u", "main.py"]


### PR DESCRIPTION
This adds [tini](https://github.com/krallin/tini) as a minimal init to ensure that signalling (SIGTERM in particular) is handled properly in containerized environments. Specifically this will ensure a timely shutdown, for example when running `docker stop …` or restarting the container. 

Thank you for making this project! 🙏 