### PR TITLE
Plex: Add GENERATE_GUIDS, remove recursive thread calls

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,6 +29,11 @@ REQUEST_TIMEOUT = 300
 ## by using the location only, useful when using same files on multiple servers
 GENERATE_GUIDS = "True"
 
+## Generate locations
+## Generating locations is a slow process, so this is a way to speed up the process
+## by using the guid only, useful when using different files on multiple servers
+GENERATE_LOCATIONS = "True"
+
 ## Max threads for processing
 MAX_THREADS = 32
 

--- a/.env.sample
+++ b/.env.sample
@@ -24,6 +24,11 @@ MARK_FILE = "mark.log"
 ## Timeout for requests for jellyfin
 REQUEST_TIMEOUT = 300
 
+## Generate guids
+## Generating guids is a slow process, so this is a way to speed up the process
+## by using the location only, useful when using same files on multiple servers
+GENERATE_GUIDS = "True"
+
 ## Max threads for processing
 MAX_THREADS = 32
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,19 @@ jobs:
 
       - name: "Run tests"
         run: |
-          # Move test/.env to root
-          mv test/ci.env .env
-          # Run script
+          # Test ci1
+          mv test/ci1.env .env
           python main.py
 
-          # Run script twice to test if it can handle existing data
+          # Test ci2
+          mv test/ci2.env .env
+          python main.py
+
+          # Test ci3
+          mv test/ci3.env .env
+          python main.py
+
+          # Test again to test if it can handle existing data
           python main.py
 
           cat mark.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
           # Run script
           python main.py
 
+          # Run script twice to test if it can handle existing data
+          python main.py
+
           cat mark.log
           python test/validate_ci_marklog.py
 

--- a/src/functions.py
+++ b/src/functions.py
@@ -93,11 +93,18 @@ def search_mapping(dictionary: dict, key_value: str):
         return None
 
 
-def future_thread_executor(args: list, threads: int = 32):
+def future_thread_executor(
+    args: list, threads: int = None, override_threads: bool = False
+):
     futures_list = []
     results = []
 
-    workers = min(int(os.getenv("MAX_THREADS", 32)), os.cpu_count() * 2, threads)
+    workers = min(int(os.getenv("MAX_THREADS", 32)), os.cpu_count() * 2)
+    if threads:
+        workers = min(threads, workers)
+
+    if override_threads:
+        workers = threads
 
     # If only one worker, run in main thread to avoid overhead
     if workers == 1:

--- a/src/plex.py
+++ b/src/plex.py
@@ -231,9 +231,9 @@ def find_video(plex_search, video_ids, videos=None):
                         if videos:
                             for show, seasons in videos.items():
                                 show = {k: v for k, v in show}
-                                if guid_source in show["ids"].keys():
-                                    if guid_id in show["ids"][guid_source]:
-                                        for season in seasons:
+                                if guid_source in show.keys():
+                                    if guid_id == show[guid_source]:
+                                        for season in seasons.values():
                                             for episode in season:
                                                 episode_videos.append(episode)
 
@@ -241,8 +241,6 @@ def find_video(plex_search, video_ids, videos=None):
 
         return False, []
     except Exception:
-        logger(f"Plex: failed to find library item for {video_ids['title']}", 2)
-        logger(traceback.format_exc(), 2)
         return False, []
 
 
@@ -272,14 +270,12 @@ def get_video_status(plex_search, video_ids, videos):
                 if guid_source in video_ids.keys():
                     if guid_id in video_ids[guid_source]:
                         for video in videos:
-                            if guid_source in video["ids"].keys():
-                                if guid_id in video["ids"][guid_source]:
+                            if guid_source in video.keys():
+                                if guid_id == video[guid_source]:
                                     return video["status"]
 
         return None
     except Exception:
-        logger(f"Plex: failed to find library item for {video_ids['title']}", 2)
-        logger(traceback.format_exc(), 2)
         return None
 
 

--- a/test/ci1.env
+++ b/test/ci1.env
@@ -1,7 +1,7 @@
 # Global Settings
 
 ## Do not mark any shows/movies as played and instead just output to log if they would of been marked.
-DRYRUN = "False"
+DRYRUN = "True"
 
 ## Additional logging information
 DEBUG = "True"
@@ -26,6 +26,16 @@ REQUEST_TIMEOUT = 300
 
 ## Max threads for processing
 MAX_THREADS = 2
+
+## Generate guids
+## Generating guids is a slow process, so this is a way to speed up the process
+# by using the location only, useful when using same files on multiple servers
+GENERATE_GUIDS = "False"
+
+## Generate locations
+## Generating locations is a slow process, so this is a way to speed up the process
+## by using the guid only, useful when using different files on multiple servers
+GENERATE_LOCATIONS = "True"
 
 ## Map usernames between servers in the event that they are different, order does not matter
 ## Comma seperated for multiple options

--- a/test/ci2.env
+++ b/test/ci2.env
@@ -1,0 +1,96 @@
+# Global Settings
+
+## Do not mark any shows/movies as played and instead just output to log if they would of been marked.
+DRYRUN = "True"
+
+## Additional logging information
+DEBUG = "True"
+
+## Debugging level, "info" is default, "debug" is more verbose
+DEBUG_LEVEL = "debug"
+
+## If set to true then the script will only run once and then exit
+RUN_ONLY_ONCE = "True"
+
+## How often to run the script in seconds
+SLEEP_DURATION = 10
+
+## Log file where all output will be written to
+LOG_FILE = "log.log"
+
+## Mark file where all shows/movies that have been marked as played will be written to
+MARK_FILE = "mark.log"
+
+## Timeout for requests for jellyfin
+REQUEST_TIMEOUT = 300
+
+## Max threads for processing
+MAX_THREADS = 2
+
+## Generate guids
+## Generating guids is a slow process, so this is a way to speed up the process
+# by using the location only, useful when using same files on multiple servers
+GENERATE_GUIDS = "True"
+
+## Generate locations
+## Generating locations is a slow process, so this is a way to speed up the process
+## by using the guid only, useful when using different files on multiple servers
+GENERATE_LOCATIONS = "False"
+
+## Map usernames between servers in the event that they are different, order does not matter
+## Comma seperated for multiple options
+USER_MAPPING = {"JellyUser":"jellyplex_watched"}
+
+## Map libraries between servers in the even that they are different, order does not matter
+## Comma seperated for multiple options
+LIBRARY_MAPPING = { "Shows": "TV Shows" }
+
+
+## Blacklisting/Whitelisting libraries, library types such as Movies/TV Shows, and users. Mappings apply so if the mapping for the user or library exist then both will be excluded.
+## Comma seperated for multiple options
+#BLACKLIST_LIBRARY = ""
+#WHITELIST_LIBRARY = "Movies"
+#BLACKLIST_LIBRARY_TYPE = "Series" 
+#WHITELIST_LIBRARY_TYPE = "Movies, movie"
+#BLACKLIST_USERS = ""
+WHITELIST_USERS = "jellyplex_watched"
+
+
+
+# Plex
+
+## Recommended to use token as it is faster to connect as it is direct to the server instead of going through the plex servers
+## URL of the plex server, use hostname or IP address if the hostname is not resolving correctly
+## Comma seperated list for multiple servers
+PLEX_BASEURL = "https://localhost:32400"
+
+## Plex token https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
+## Comma seperated list for multiple servers
+PLEX_TOKEN = "mVaCzSyd78uoWkCBzZ_Y"
+
+## If not using plex token then use username and password of the server admin along with the servername
+## Comma seperated for multiple options
+#PLEX_USERNAME = "PlexUser, PlexUser2"
+#PLEX_PASSWORD = "SuperSecret, SuperSecret2"
+#PLEX_SERVERNAME = "Plex Server1, Plex Server2"
+
+## Skip hostname validation for ssl certificates.
+## Set to True if running into ssl certificate errors
+SSL_BYPASS = "True"
+
+## control the direction of syncing. e.g. SYNC_FROM_PLEX_TO_JELLYFIN set to true will cause the updates from plex
+## to be updated in jellyfin. SYNC_FROM_PLEX_TO_PLEX set to true will sync updates between multiple plex servers
+SYNC_FROM_PLEX_TO_JELLYFIN = "True"
+SYNC_FROM_JELLYFIN_TO_PLEX = "True"
+SYNC_FROM_PLEX_TO_PLEX = "True"
+SYNC_FROM_JELLYFIN_TO_JELLYFIN = "True"
+
+# Jellyfin
+
+## Jellyfin server URL, use hostname or IP address if the hostname is not resolving correctly
+## Comma seperated list for multiple servers
+JELLYFIN_BASEURL = "http://localhost:8096"
+
+## Jellyfin api token, created manually by logging in to the jellyfin server admin dashboard and creating an api key
+## Comma seperated list for multiple servers
+JELLYFIN_TOKEN = "d773c4db3ecc4b028fc0904d9694804c"

--- a/test/ci3.env
+++ b/test/ci3.env
@@ -1,0 +1,96 @@
+# Global Settings
+
+## Do not mark any shows/movies as played and instead just output to log if they would of been marked.
+DRYRUN = "False"
+
+## Additional logging information
+DEBUG = "True"
+
+## Debugging level, "info" is default, "debug" is more verbose
+DEBUG_LEVEL = "debug"
+
+## If set to true then the script will only run once and then exit
+RUN_ONLY_ONCE = "True"
+
+## How often to run the script in seconds
+SLEEP_DURATION = 10
+
+## Log file where all output will be written to
+LOG_FILE = "log.log"
+
+## Mark file where all shows/movies that have been marked as played will be written to
+MARK_FILE = "mark.log"
+
+## Timeout for requests for jellyfin
+REQUEST_TIMEOUT = 300
+
+## Max threads for processing
+MAX_THREADS = 2
+
+## Generate guids
+## Generating guids is a slow process, so this is a way to speed up the process
+# by using the location only, useful when using same files on multiple servers
+GENERATE_GUIDS = "True"
+
+## Generate locations
+## Generating locations is a slow process, so this is a way to speed up the process
+## by using the guid only, useful when using different files on multiple servers
+GENERATE_LOCATIONS = "True"
+
+## Map usernames between servers in the event that they are different, order does not matter
+## Comma seperated for multiple options
+USER_MAPPING = {"JellyUser":"jellyplex_watched"}
+
+## Map libraries between servers in the even that they are different, order does not matter
+## Comma seperated for multiple options
+LIBRARY_MAPPING = { "Shows": "TV Shows" }
+
+
+## Blacklisting/Whitelisting libraries, library types such as Movies/TV Shows, and users. Mappings apply so if the mapping for the user or library exist then both will be excluded.
+## Comma seperated for multiple options
+#BLACKLIST_LIBRARY = ""
+#WHITELIST_LIBRARY = "Movies"
+#BLACKLIST_LIBRARY_TYPE = "Series" 
+#WHITELIST_LIBRARY_TYPE = "Movies, movie"
+#BLACKLIST_USERS = ""
+WHITELIST_USERS = "jellyplex_watched"
+
+
+
+# Plex
+
+## Recommended to use token as it is faster to connect as it is direct to the server instead of going through the plex servers
+## URL of the plex server, use hostname or IP address if the hostname is not resolving correctly
+## Comma seperated list for multiple servers
+PLEX_BASEURL = "https://localhost:32400"
+
+## Plex token https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
+## Comma seperated list for multiple servers
+PLEX_TOKEN = "mVaCzSyd78uoWkCBzZ_Y"
+
+## If not using plex token then use username and password of the server admin along with the servername
+## Comma seperated for multiple options
+#PLEX_USERNAME = "PlexUser, PlexUser2"
+#PLEX_PASSWORD = "SuperSecret, SuperSecret2"
+#PLEX_SERVERNAME = "Plex Server1, Plex Server2"
+
+## Skip hostname validation for ssl certificates.
+## Set to True if running into ssl certificate errors
+SSL_BYPASS = "True"
+
+## control the direction of syncing. e.g. SYNC_FROM_PLEX_TO_JELLYFIN set to true will cause the updates from plex
+## to be updated in jellyfin. SYNC_FROM_PLEX_TO_PLEX set to true will sync updates between multiple plex servers
+SYNC_FROM_PLEX_TO_JELLYFIN = "True"
+SYNC_FROM_JELLYFIN_TO_PLEX = "True"
+SYNC_FROM_PLEX_TO_PLEX = "True"
+SYNC_FROM_JELLYFIN_TO_JELLYFIN = "True"
+
+# Jellyfin
+
+## Jellyfin server URL, use hostname or IP address if the hostname is not resolving correctly
+## Comma seperated list for multiple servers
+JELLYFIN_BASEURL = "http://localhost:8096"
+
+## Jellyfin api token, created manually by logging in to the jellyfin server admin dashboard and creating an api key
+## Comma seperated list for multiple servers
+JELLYFIN_TOKEN = "d773c4db3ecc4b028fc0904d9694804c"

--- a/test/validate_ci_marklog.py
+++ b/test/validate_ci_marklog.py
@@ -60,6 +60,9 @@ def main():
         "JellyUser/Shows/Monarch: Legacy of Monsters/Secrets and Lies",
     ]
 
+    # Triple the expected values because the CI runs three times
+    expected_values = expected_values * 3
+
     lines = read_marklog()
     if not check_marklog(lines, expected_values):
         print("Failed to validate marklog")


### PR DESCRIPTION
Adds a GENERATE_GUIDS environment variable so guids can be skipped due to how slow the process can be, this is very useful if you using the same media files across many servers or if you are using a media manager with a standardized template.

Removes recursive thread calling so the amount of threads doesnt spike like crazy when doing many libraries/users. Makes the amount of threads being used more closely connected to the MAX_THREADS environment variable