### PR TITLE
Plex: fix guid lookup for X -> Plex sync

### DIFF
--- a/src/plex.py
+++ b/src/plex.py
@@ -209,6 +209,8 @@ def find_video(plex_search, video_ids, videos=None):
 
         return False, []
     except Exception:
+        logger(f"Plex: failed to find library item for {video_ids['title']}", 2)
+        logger(traceback.format_exc(), 2)
         return False, []
 
 
@@ -240,6 +242,8 @@ def get_video_status(plex_search, video_ids, videos):
 
         return None
     except Exception:
+        logger(f"Plex: failed to find library item for {video_ids['title']}", 2)
+        logger(traceback.format_exc(), 2)
         return None
 
 

--- a/src/plex.py
+++ b/src/plex.py
@@ -199,9 +199,9 @@ def find_video(plex_search, video_ids, videos=None):
                     if videos:
                         for show, seasons in videos.items():
                             show = {k: v for k, v in show}
-                            if guid_source in show["ids"].keys():
-                                if guid_id in show["ids"][guid_source]:
-                                    for season in seasons:
+                            if guid_source in show.keys():
+                                if guid_id == show[guid_source]:
+                                    for season in seasons.values():
                                         for episode in season:
                                             episode_videos.append(episode)
 
@@ -234,8 +234,8 @@ def get_video_status(plex_search, video_ids, videos):
             if guid_source in video_ids.keys():
                 if guid_id in video_ids[guid_source]:
                     for video in videos:
-                        if guid_source in video["ids"].keys():
-                            if guid_id in video["ids"][guid_source]:
+                        if guid_source in video.keys():
+                            if guid_id == video[guid_source]:
                                 return video["status"]
 
         return None


### PR DESCRIPTION
This PR aims to resolve #108 by fixing 2 issues within the guid matching for plex:
1. The guid lookup on plex was checking under the "ids" key on the `user_watched` dicts, rather than directly on the dict, where the guids seem to be located (alongside `location` and `title`). This PR switches it to check directly against the dict itself.
2. `find_video` was attempting to iterate over `season` the *key* (e.g. 1, 2, etc) rather than the list of episodes. This PR switches to match the logic for location based lookups a few lines above

I've also added additional logging to hopefully help catch any similar issues in the future.


I haven't run this change very long yet, but the changes are minor and I have been able to sync both Jellyfin -> Plex, and Plex -> Jellyfin (where previously Jellyfin -> Plex would fail silently for me similar to what's noted in #108)

Thanks!