### PR TITLE
Check Jellyfin/Emby version before attempting partial update

### DIFF
--- a/src/emby.py
+++ b/src/emby.py
@@ -19,3 +19,8 @@ class Emby(JellyfinEmby):
         super().__init__(
             server_type="Emby", baseurl=baseurl, token=token, headers=headers
         )
+    
+    def is_partial_update_supported(self, version):
+        version_parts = version.split('.')
+        major, minor, patch = map(int, version_parts[:3])
+        return major > 4 or (major >= 4 and minor >= 4)

--- a/src/jellyfin.py
+++ b/src/jellyfin.py
@@ -19,3 +19,8 @@ class Jellyfin(JellyfinEmby):
         super().__init__(
             server_type="Jellyfin", baseurl=baseurl, token=token, headers=headers
         )
+        
+    def is_partial_update_supported(self, version):
+        version_parts = version.split('.')
+        major, minor, patch = map(int, version_parts[:3])
+        return major > 10 or (major >= 10 and minor >= 9)


### PR DESCRIPTION
- add `is_partial_update_supported` method to each class to validate given version against earliest known supported version
- add `get_server_version` to get server version number
- add `update_partial` parameter to user update function, deciding whether or not to allow partial updates

ref: [#176 ](https://github.com/luigi311/JellyPlex-Watched/issues/176) 