### PR TITLE
allow sync direction to be set per user

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -41,6 +41,10 @@ MAX_THREADS = 32
 ## Comma separated for multiple options
 #USER_MAPPING = { "testuser2": "testuser3", "testuser1":"testuser4" }
 
+## For a given user only decide to sync to the servers in the list. One can control which users sync in which direction.
+## This is optional. If not present then the sync settings will sync all users based on the direction of the sync enabled.
+# USER_SERVER_SYNC_MAPPING = { "testuser2": ["jellyfin"]}
+
 ## Map libraries between servers in the event that they are different, order does not matter
 ## Comma separated for multiple options
 #LIBRARY_MAPPING = { "Shows": "TV Shows", "Movie": "Movies" }

--- a/src/main.py
+++ b/src/main.py
@@ -101,7 +101,7 @@ def main_loop():
     user_server_sync_mapping = os.getenv("USER_SERVER_SYNC_MAPPING")
     if user_server_sync_mapping:
         user_server_sync_mapping = json.loads(user_server_sync_mapping.lower())
-        logger(f"User Server Mapping: {user_server_sync_mapping}", 1)
+        logger(f"User Server Sync Mapping: {user_server_sync_mapping}", 1)
 
     library_mapping = os.getenv("LIBRARY_MAPPING")
     if library_mapping:

--- a/src/main.py
+++ b/src/main.py
@@ -97,7 +97,7 @@ def main_loop():
     if user_mapping:
         user_mapping = json.loads(user_mapping.lower())
         logger(f"User Mapping: {user_mapping}", 1)
-    
+
     user_server_sync_mapping = os.getenv("USER_SERVER_SYNC_MAPPING")
     if user_server_sync_mapping:
         user_server_sync_mapping = json.loads(user_server_sync_mapping.lower())

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,10 @@ from src.functions import (
     logger,
     str_to_bool,
 )
-from src.users import setup_users
+from src.users import (
+    setup_users,
+    sync_users
+)
 from src.watched import (
     cleanup_watched,
 )
@@ -94,6 +97,11 @@ def main_loop():
     if user_mapping:
         user_mapping = json.loads(user_mapping.lower())
         logger(f"User Mapping: {user_mapping}", 1)
+    
+    user_server_mapping = os.getenv("USER_SERVER_MAPPING")
+    if user_server_mapping:
+        user_server_mapping = json.loads(user_server_mapping.lower())
+        logger(f"User Server Mapping: {user_server_mapping}", 1)
 
     library_mapping = os.getenv("LIBRARY_MAPPING")
     if library_mapping:
@@ -197,19 +205,21 @@ def main_loop():
             )
 
             if should_sync_server(server_2[0], server_1[0]):
+                sync_to_server1_users = sync_users(user_mapping, user_server_mapping, server_1[0])
                 logger(f"Syncing {server_2[1].info()} -> {server_1[1].info()}", 0)
                 server_1[1].update_watched(
                     server_2_watched_filtered,
-                    user_mapping,
+                    sync_to_server1_users,
                     library_mapping,
                     dryrun,
                 )
 
             if should_sync_server(server_1[0], server_2[0]):
+                sync_to_server2_users = sync_users(user_mapping, user_server_mapping, server_2[0])
                 logger(f"Syncing {server_1[1].info()} -> {server_2[1].info()}", 0)
                 server_2[1].update_watched(
                     server_1_watched_filtered,
-                    user_mapping,
+                    sync_to_server2_users,
                     library_mapping,
                     dryrun,
                 )

--- a/src/main.py
+++ b/src/main.py
@@ -98,10 +98,10 @@ def main_loop():
         user_mapping = json.loads(user_mapping.lower())
         logger(f"User Mapping: {user_mapping}", 1)
     
-    user_server_mapping = os.getenv("USER_SERVER_MAPPING")
-    if user_server_mapping:
-        user_server_mapping = json.loads(user_server_mapping.lower())
-        logger(f"User Server Mapping: {user_server_mapping}", 1)
+    user_server_sync_mapping = os.getenv("USER_SERVER_SYNC_MAPPING")
+    if user_server_sync_mapping:
+        user_server_sync_mapping = json.loads(user_server_sync_mapping.lower())
+        logger(f"User Server Mapping: {user_server_sync_mapping}", 1)
 
     library_mapping = os.getenv("LIBRARY_MAPPING")
     if library_mapping:
@@ -205,7 +205,7 @@ def main_loop():
             )
 
             if should_sync_server(server_2[0], server_1[0]):
-                sync_to_server1_users = sync_users(user_mapping, user_server_mapping, server_1[0])
+                sync_to_server1_users = sync_users(user_mapping, user_server_sync_mapping, server_1[0])
                 logger(f"Syncing {server_2[1].info()} -> {server_1[1].info()}", 0)
                 server_1[1].update_watched(
                     server_2_watched_filtered,
@@ -215,7 +215,7 @@ def main_loop():
                 )
 
             if should_sync_server(server_1[0], server_2[0]):
-                sync_to_server2_users = sync_users(user_mapping, user_server_mapping, server_2[0])
+                sync_to_server2_users = sync_users(user_mapping, user_server_sync_mapping, server_2[0])
                 logger(f"Syncing {server_1[1].info()} -> {server_2[1].info()}", 0)
                 server_2[1].update_watched(
                     server_1_watched_filtered,

--- a/src/users.py
+++ b/src/users.py
@@ -139,7 +139,7 @@ def sync_users(original_user_mapping, user_server_sync_mapping, server_type):
     # if no overrides are defined then return original mapping.
     if user_server_sync_mapping is None:
         return original_user_mapping
-    
+
     user_mapping = copy(original_user_mapping)
     for user in original_user_mapping.keys():
         # if the user override exists in server mapping and server type is not one of the servers

--- a/src/users.py
+++ b/src/users.py
@@ -3,6 +3,8 @@ from src.functions import (
     search_mapping,
 )
 
+from copy import copy
+
 
 def generate_user_list(server):
     # generate list of users from server 1 and server 2
@@ -131,3 +133,18 @@ def setup_users(
     logger(f"Server 2 users: {output_server_2_users}", 1)
 
     return output_server_1_users, output_server_2_users
+
+
+def sync_users(original_user_mapping, user_server_mapping, server_type):
+    # if no overrides are defined then return original mapping.
+    if user_server_mapping is None:
+        return original_user_mapping
+    
+    user_mapping = copy(original_user_mapping)
+    for user in original_user_mapping.keys():
+        # if the user override exists in server mapping and server type is not one of the servers
+        # we want to sync then we will remove it from the users we want to map.
+        if user in user_server_mapping and server_type not in user_server_mapping.get(user):
+            del user_mapping[user]
+
+    return user_mapping

--- a/src/users.py
+++ b/src/users.py
@@ -135,16 +135,16 @@ def setup_users(
     return output_server_1_users, output_server_2_users
 
 
-def sync_users(original_user_mapping, user_server_mapping, server_type):
+def sync_users(original_user_mapping, user_server_sync_mapping, server_type):
     # if no overrides are defined then return original mapping.
-    if user_server_mapping is None:
+    if user_server_sync_mapping is None:
         return original_user_mapping
     
     user_mapping = copy(original_user_mapping)
     for user in original_user_mapping.keys():
         # if the user override exists in server mapping and server type is not one of the servers
         # we want to sync then we will remove it from the users we want to map.
-        if user in user_server_mapping and server_type not in user_server_mapping.get(user):
+        if user in user_server_sync_mapping and server_type not in user_server_sync_mapping.get(user):
             del user_mapping[user]
 
     return user_mapping

--- a/test/test_users.py
+++ b/test/test_users.py
@@ -16,6 +16,7 @@ sys.path.append(parent)
 from src.users import (
     combine_user_lists,
     filter_user_lists,
+    sync_users
 )
 
 
@@ -37,3 +38,26 @@ def test_filter_user_lists():
     filtered = filter_user_lists(users, blacklist_users, whitelist_users)
 
     assert filtered == {"test": "test2", "luigi311": "luigi311"}
+
+def test_sync_users():
+    users = { "user1": "user1", "user2": "user2", "user3": "user3" }
+
+    # empty sync users returns original list
+    users_to_sync = sync_users(users, {}, 'jellyfin')
+    assert users_to_sync == users
+
+    # None sync users returns original list
+    users_to_sync = sync_users(users, None, 'jellyfin')
+    assert users_to_sync == users
+
+    # sync user not in orignal list returns original list
+    users_to_sync = sync_users(users, { "user4": ['plex'] }, 'jellyfin')
+    assert users_to_sync == users
+
+    # sync user syncing expected server returns original list
+    users_to_sync = sync_users(users, { "user3": ['jellyfin'] }, 'jellyfin')
+    assert users_to_sync == users
+
+    # sync user removed as it is not syncing the server expected.
+    users_to_sync = sync_users(users, { "user2": ['plex'] }, 'jellyfin')
+    assert users_to_sync == { "user1": "user1", "user3": "user3" }


### PR DESCRIPTION
I have not tested this yet. Just wanted to see if the approach looked feasible. This would implement #150.

User would define an optional env var: `USER_SERVER_SYNC_MAPPING=['jellyfin']`

This essentially says which servers do we want to sync to.

`sync_users` method then returns an updated list of users we want to sync based on this variables.

If this approach looks good I will work on validating it and documenting it.

Current approach is not ideal as ideally if we are not going to sync from Plex to Jellyfin then we can avoid collecting the matched data for that user as well. But I wanted to avoid too much change.

In future if we plan on re writing this then I would suggest a more complex setting for users config where we also capture the name and servers to sync etc. Something like

```

{

  "user": {
    "name": "xyz",
    "sync": {
      "plex": ["jellyfin", "emby", "jellyfin2"]
    }
  },
  "servers": {
    "plex:": {
      "token": "xx",
      "url": "xx",
      "type": "plex"
    },
    "jellyfin:": {
      "token": "xx",
      "url": "xx",
      "type": "jellyfin"
    },
    "emby:": {
      "token": "xx",
      "url": "xx",
      "type": "emby"
    },
    "jellyfin2:": {
      "token": "xx",
      "url": "xx",
      "type": "jellyfin"
    }
  }
 
}

```

Something like above could allow one to explicitly decide what servers to sync and in what direction for each user. This way one could any number and types of servers and be able to control what to sync to as well.
