### PR TITLE
Plex: only fetch watched or partially watched episodes

### DIFF
--- a/src/plex.py
+++ b/src/plex.py
@@ -322,12 +322,14 @@ class Plex:
                     processed_shows.append(show.key)
                     show_guids = extract_guids_from_item(show)
                     episode_mediaitem = []
-                    for episode in show.episodes():
-                        if episode.isWatched or episode.viewOffset >= 60000:
 
-                            episode_mediaitem.append(
-                                get_mediaitem(episode, episode.isWatched)
-                            )
+                    # Fetch watched or partially watched episodes
+                    for episode in show.watched() + show.episodes(
+                        viewOffset__gte=60_000
+                    ):
+                        episode_mediaitem.append(
+                            get_mediaitem(episode, episode.isWatched)
+                        )
 
                     if episode_mediaitem:
                         watched.series.append(


### PR DESCRIPTION
Instead of fetching all episodes and checking if watched or view time it is faster to search for only watched and partially watched episodes.