### PR TITLE
fix: case-insensitive library name check for jellyfin/emby

### DIFF
--- a/src/jellyfin_emby.py
+++ b/src/jellyfin_emby.py
@@ -764,7 +764,7 @@ class JellyfinEmby:
 
                     library_id = None
                     for jellyfin_library in jellyfin_libraries:
-                        if jellyfin_library["Name"] == library_name:
+                        if jellyfin_library["Name"].lower() == library_name.lower():
                             library_id = jellyfin_library["Id"]
                             continue
 


### PR DESCRIPTION
Made library name comparison case-insensitive in Jellyfin/Emby library matching.

## Changes
- Modified the library name comparison in `update_watched()` to use case-insensitive matching
- This change ensures library names like "Tv Shows", and "TV shows" are treated as the same library

## Why
- Previously, library name matching was case-sensitive, and if someone had library mappings that differed only by case (e.g., TV Shows => TV shows), it caused inconsistencies since earlier checks were case-insensitive, and syncing was skipped.
- This change makes the behavior consistent with the earlier case-insensitive checks in the file

