### PR TITLE
Added way to match paths based on an arbitrary level

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -49,6 +49,12 @@ LIBRARY_MAPPING = { "Shows": "TV Shows", "Movie": "Movies" }
 #BLACKLIST_USERS = ""
 #WHITELIST_USERS = ""
 
+## How many parts of the file path to use when matching locations.
+## 0 = full path (default)
+## >0 = number of path parts from the end of the path to use (e.g. 1 = filename only, 2 = last directory + filename, etc)
+## Useful if different servers have different root paths but the same subdirectory structure (e.g. C:\\Media\\Anime\\Show vs /data/anime/Show)
+MEDIA_LOCATION_MATCH_LEVEL = "0"
+
 
 # Plex
 


### PR DESCRIPTION
These are some changes i needed to get my Plex on windows to synchronize with jellyfin in docker.

The changes address 2 main problem:

- path separator across Windows and linux are not the same
- Allow matching files even if the root of the file location differs
  I am matching starting from the end of the path to allow arbitrary different length of the root prefix

In my case no files were being synchronized due to the data collected from Plex having `None` on all IDs, leaving the path to be the only way to perform the match, which was failing due to the difference in path separator and root location of the library (in my case `windows ->linux`, but also `linux -> linux` could fail if the root is altered by using different bind location in different containers
