### PR TITLE
Utilize pathlib for universal location file extraction

### DIFF
--- a/src/functions.py
+++ b/src/functions.py
@@ -2,6 +2,8 @@ import os
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Callable
 from dotenv import load_dotenv
+import re
+from pathlib import PureWindowsPath, PurePosixPath
 
 load_dotenv(override=True)
 
@@ -124,3 +126,13 @@ def parse_string_to_list(string: str | None) -> list[str]:
         output = string.split(",")
 
     return output
+
+
+_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:")  # e.g. C: D:
+
+
+def filename_from_any_path(p: str) -> str:
+    # Windows-y if UNC (\\server\share), drive letter, or has backslashes
+    if p.startswith("\\\\") or _WINDOWS_DRIVE.match(p) or ("\\" in p and "/" not in p):
+        return PureWindowsPath(p).name
+    return PurePosixPath(p).name

--- a/src/jellyfin_emby.py
+++ b/src/jellyfin_emby.py
@@ -9,6 +9,7 @@ from packaging.version import parse, Version
 from loguru import logger
 
 from src.functions import (
+    filename_from_any_path,
     search_mapping,
     log_marked,
     str_to_bool,
@@ -46,10 +47,10 @@ def extract_identifiers_from_item(
     if generate_locations:
         if item.get("Path"):
             full_path = item["Path"]
-            locations = tuple([full_path.split("/")[-1]])
+            locations = tuple([filename_from_any_path(full_path)])
         elif item.get("MediaSources"):
             full_paths = [x["Path"] for x in item["MediaSources"] if x.get("Path")]
-            locations = tuple([x.split("/")[-1] for x in full_paths])
+            locations = tuple([filename_from_any_path(x) for x in full_paths])
             full_path = " ".join(full_paths)
 
     if generate_guids:
@@ -406,7 +407,7 @@ class JellyfinEmby:
                         k.lower(): v for k, v in show.get("ProviderIds", {}).items()
                     }
                     show_locations = (
-                        tuple([show["Path"].split("/")[-1]])
+                        tuple([filename_from_any_path(show["Path"])])
                         if show.get("Path")
                         else tuple()
                     )

--- a/src/plex.py
+++ b/src/plex.py
@@ -13,6 +13,7 @@ from plexapi.myplex import MyPlexAccount, MyPlexUser
 from plexapi.library import MovieSection, ShowSection
 
 from src.functions import (
+    filename_from_any_path,
     search_mapping,
     log_marked,
     str_to_bool,
@@ -66,7 +67,7 @@ def extract_identifiers_from_item(
 ) -> MediaIdentifiers:
     guids = extract_guids_from_item(item, generate_guids)
     locations = (
-        tuple([location.split("/")[-1] for location in item.locations])
+        tuple([filename_from_any_path(loc) for loc in item.locations])
         if generate_locations
         else tuple()
     )
@@ -278,7 +279,7 @@ class Plex:
                                     locations=(
                                         tuple(
                                             [
-                                                location.split("/")[-1]
+                                                filename_from_any_path(location)
                                                 for location in show.locations
                                             ]
                                         )


### PR DESCRIPTION
Replaces the current location extraction method with a more universal method that works with windowsy based path strings. Right now its hard coded to split on / and extract the final section, that never works on windows paths due to them using \ and sometimes \\\\. 

Supersedes #307 