### PR TITLE
Watched: Drop missing view_date comparisons so required on both

### DIFF
--- a/src/watched.py
+++ b/src/watched.py
@@ -78,12 +78,6 @@ def compare_media_items(media1: MediaItem, media2: MediaItem) -> Ord:
     ):
         return Ord.A_BETTER if media1_viewed_date > media2_viewed_date else Ord.B_BETTER
 
-    if media1_viewed_date and not media2_viewed_date:
-        return Ord.A_BETTER
-
-    if media2_viewed_date and not media1_viewed_date:
-        return Ord.B_BETTER
-
     # Next, compare completed status
     if media1.status.completed != media2.status.completed:
         return Ord.A_BETTER if media1.status.completed else Ord.B_BETTER


### PR DESCRIPTION
Do not do a view_date comparison unless both servers have a view_date.