### PR TITLE
Fix partial-only TV shows re-syncing every run

### DIFF
--- a/src/jellyfin_emby.py
+++ b/src/jellyfin_emby.py
@@ -375,10 +375,28 @@ class JellyfinEmby:
                     )
                     return watched
 
+                # Fetch series IDs that have resumable (partially watched) episodes
+                resumable_episodes = self.query(
+                    f"/Users/{user_id}/Items"
+                    + f"?ParentId={library_id}&Filters=IsResumable&IncludeItemTypes=Episode&Recursive=True&Fields=SeriesId",
+                    "get",
+                )
+                resumable_series_ids = set()
+                if resumable_episodes and isinstance(resumable_episodes, dict):
+                    for ep in resumable_episodes.get("Items", []):
+                        series_id = ep.get("SeriesId")
+                        if series_id:
+                            resumable_series_ids.add(series_id)
+
                 # Filter the list of shows to only include those that have been partially or fully watched
                 watched_shows_filtered = []
                 for show in all_shows.get("Items", []):
                     if not show.get("UserData"):
+                        continue
+
+                    # Include shows with resumable episodes even if none are fully played
+                    if show.get("Id") in resumable_series_ids:
+                        watched_shows_filtered.append(show)
                         continue
 
                     played_percentage = show["UserData"].get("PlayedPercentage")


### PR DESCRIPTION
Fixes: #355 

Jellyfin's UnplayedItemCount does not decrease for partially-watched episodes that are not marked played, causing shows with only partial progress to be excluded from the read-back watched list. This means the dedup/cleanup step never finds a match and re-syncs the same partial episodes on every run.

Fix: query IsResumable episodes to collect series IDs with in-progress episodes, and include those shows in the watched list regardless of played count. Mirrors the existing IsResumable logic already used for movies.